### PR TITLE
Limit chef-sugar version because >=5.0.0 need Chef >=13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ depends 'apt'
 depends 'yum', '>= 3.8.1'
 depends 'yum-epel'
 depends 'poise', '>= 2.5.0'
-depends 'chef-sugar', '>= 3.3.0'
+depends 'chef-sugar', '~> 4.2.2'
 depends 'chef-vault', '>= 2.1'
 
 supports 'ubuntu', '>= 14.04'


### PR DESCRIPTION
5.0.1 was the last version that worked for us